### PR TITLE
Add offset for getFlatRateFulfillmentRestrictions query

### DIFF
--- a/src/schemas/restrictions.graphql
+++ b/src/schemas/restrictions.graphql
@@ -94,6 +94,9 @@ extend type Query {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = desc,
 


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Issue: https://github.com/reactioncommerce/reaction/issues/6252
Impact: **minor**
Type: **bugfix**

## Issue
Missing offset params for pagination for getFlatRateFulfillmentRestrictions query