### PR TITLE
(feat) Add regex matching for P.O. Box filtering and others

### DIFF
--- a/src/util/isDestinationRestricted.js
+++ b/src/util/isDestinationRestricted.js
@@ -25,5 +25,18 @@ export default function isDestinationRestricted(destination, shippingAddress) {
     return true;
   }
 
+  /**
+   * This adds support for address regex match on address1 and address2
+   * It is required to implement basic match against PO Box addresses
+   */
+  if (destination.addressPattern) {
+    const { addressPatternShouldMatch = true } = destination;
+    const fullAddress = [shippingAddress.address1, shippingAddress.address2].join(" ");
+    const addressMatchesPattern = RegExp(destination.addressPattern, "ig").test(fullAddress);
+    if ((addressMatchesPattern && addressPatternShouldMatch) || (!addressMatchesPattern && !addressPatternShouldMatch)) {
+      return true;
+    }
+  }
+
   return false;
 }


### PR DESCRIPTION
Resolves #None
Impact: **minor**
Type: **feature**

## Issue
It is impossible to currently allow/deny methods based on address type like P.O. Boxes which cannot accept shipments like 3rd party couriers like UPS or FedEx.

## Solution
Add the ability to match addresses by Regex

## Breaking changes
None. You don't need to utilize this feature if you don't want.


